### PR TITLE
Updating to reference the year.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-christchurch.nodeconf.com
+2015.christchurch.nodeconf.com


### PR DESCRIPTION
This conference already happened so we'll want to open up christchurch.nodeconf.com for next year's event. Should probably also rename the repository.
